### PR TITLE
Added '--json' option which allows to dump all stats.

### DIFF
--- a/beem/__init__.py
+++ b/beem/__init__.py
@@ -50,11 +50,11 @@ def json_dump_stats(stats, path):
     write the stats object to disk.
     """
     try:
-       with open(path, 'w') as f:  
+       with open(path, 'w') as f:
            json.dump(stats, f)
        print("Wrote stats to: {}".format(path))
     except IOError:
-        print "Couldn't dump JSON stats to: {}".format(path)
+        print("Couldn't dump JSON stats to: {}".format(path))
         
 
 def aggregate_publish_stats(stats_set):

--- a/beem/__init__.py
+++ b/beem/__init__.py
@@ -25,6 +25,7 @@
 Basic helper routines that might be needed in multiple places.
 Also, just a place holder for the package.
 """
+import json
 
 
 def print_publish_stats(stats):
@@ -43,6 +44,18 @@ def print_publish_stats(stats):
     print("Messages per second   %.2f" % stats["msgs_per_sec"])
     print("Total time            %.2f secs" % stats["time_total"])
 
+
+def json_dump_stats(stats, path):
+    """
+    write the stats object to disk.
+    """
+    try:
+       with open(path, 'w') as f:  
+           json.dump(stats, f)
+       print("Wrote stats to: {}".format(path))
+    except IOError:
+        print "Couldn't dump JSON stats to: {}".format(path)
+        
 
 def aggregate_publish_stats(stats_set):
     """

--- a/beem/cmds/publish.py
+++ b/beem/cmds/publish.py
@@ -218,5 +218,4 @@ def run(options):
             x["time_total"] = time_end - time_start
         [beem.print_publish_stats(x) for x in agg_stats_set]
         if options.json is not None:
-            [beem.json_dump_stats(x, options.json) for x in agg_stats_set]
-
+            beem.json_dump_stats(agg_stats_set, options.json)

--- a/beem/cmds/publish.py
+++ b/beem/cmds/publish.py
@@ -146,6 +146,9 @@ def add_args(subparsers):
         help="""A file of psk 'identity:key' pairs, as you would pass to
 mosquitto's psk_file configuration option.  Each process will use a single
 line from the file.  Only as many processes will be made as there are keys""")
+    parser.add_argument(
+        "--json", type=str, default=None,
+        help="""Dump the collected stats into the given JSON file.""")
 
     parser.set_defaults(handler=run)
 
@@ -207,8 +210,13 @@ def run(options):
         agg_stats = beem.aggregate_publish_stats(stats_set)
         agg_stats["time_total"] = time_end - time_start
         beem.print_publish_stats(agg_stats)
+        if options.json is not None:
+            beem.json_dump_stats(agg_stats, options.json)
     else:
         agg_stats_set = [beem.aggregate_publish_stats(x) for x in stats_set]
         for x in agg_stats_set:
             x["time_total"] = time_end - time_start
         [beem.print_publish_stats(x) for x in agg_stats_set]
+        if options.json is not None:
+            [beem.json_dump_stats(x, options.json) for x in agg_stats_set]
+

--- a/beem/cmds/subscribe.py
+++ b/beem/cmds/subscribe.py
@@ -89,6 +89,9 @@ def add_args(subparsers):
         "-t", "--topic", default="mqtt-malaria/+/data/#",
         help="""Topic to subscribe to, will be sorted into clients by the
          '+' symbol""")
+    parser.add_argument(
+        "--json", type=str, default=None,
+        help="""Dump the collected stats into the given JSON file.""")
 
     parser.set_defaults(handler=run)
 
@@ -97,3 +100,5 @@ def run(options):
     ts = beem.listen.TrackingListener(options.host, options.port, options)
     ts.run(options.qos)
     print_stats(ts.stats())
+    if options.json is not None:
+        beem.json_dump_stats(ts.stats(), options.json)


### PR DESCRIPTION
New option '--json <path>' allows to dump all collected statistics to the given JSON file at the end
of a run. This makes reusing/parsing the results with
other tools much easier.
Implemented for publish and subscribe.
